### PR TITLE
fix: 修复文件名解析截断问题和导入重试上传状态未清空问题

### DIFF
--- a/src/components/ScenePackage/ImportDialog.vue
+++ b/src/components/ScenePackage/ImportDialog.vue
@@ -63,7 +63,7 @@ import { Loading, Upload } from "@element-plus/icons-vue";
 
 import { importScene } from "@/services/scene-package/import-service";
 
-import type { UploadFile } from "element-plus";
+import type { UploadFile, UploadInstance } from "element-plus";
 
 // ============================================================================
 // Props & Emits
@@ -87,6 +87,11 @@ const state = ref<ImportState>("idle");
 const importing = ref(false);
 const importError = ref("");
 const newVerseId = ref(0);
+const uploadRef = ref<UploadInstance>();
+
+const clearUploadState = () => {
+  uploadRef.value?.clearFiles();
+};
 
 // ============================================================================
 // 方法
@@ -136,6 +141,7 @@ const handleNavigate = () => {
 const handleRetry = () => {
   state.value = "idle";
   importError.value = "";
+  clearUploadState();
 };
 
 const handleClose = () => {
@@ -149,6 +155,7 @@ const resetState = () => {
   importing.value = false;
   importError.value = "";
   newVerseId.value = 0;
+  clearUploadState();
 };
 </script>
 

--- a/src/services/scene-package/export-service.ts
+++ b/src/services/scene-package/export-service.ts
@@ -20,8 +20,17 @@ export function extractFilename(
   fallbackId: number
 ): string {
   if (contentDisposition) {
-    const match = contentDisposition.match(/filename="?([^";\s]+)"?/);
-    if (match?.[1]) return match[1];
+    // filename*=UTF-8''encoded%20name.zip
+    const encodedMatch = contentDisposition.match(/filename\*\s*=\s*[^']*'[^']*'([^;]+)/i);
+    if (encodedMatch?.[1]) return decodeURIComponent(encodedMatch[1].trim());
+
+    // filename="scene package.zip"
+    const quotedMatch = contentDisposition.match(/filename\s*=\s*"([^"]+)"/i);
+    if (quotedMatch?.[1]) return quotedMatch[1];
+
+    // filename=scene.zip
+    const unquotedMatch = contentDisposition.match(/filename\s*=\s*([^;]+)/i);
+    if (unquotedMatch?.[1]) return unquotedMatch[1].trim();
   }
   return `scene_${fallbackId}.zip`;
 }


### PR DESCRIPTION
## 问题描述

代码审查发现 2 个 P2 级 Bug：

### Bug 1: 文件名解析截断（export-service.ts）
- **问题**：正则 `/filename="?([^";\s]+)"?/` 在遇到含空格文件名时会截断，如 `my scene.zip` 解析成 `my`
- **修复**：改进正则，依次匹配 `filename*`（RFC 5987编码）、带引号格式、不带引号格式

### Bug 2: 导入重试时上传状态未清空（ImportDialog.vue）
- **问题**：失败后点击重试只重置了状态文本，`el-upload` 内部文件未清空，再次选同一文件不触发 `change` 事件
- **修复**：添加 `uploadRef`，在 `handleRetry` 和 `resetState` 中调用 `clearFiles()`

## 改动文件
- `src/services/scene-package/export-service.ts`
- `src/components/ScenePackage/ImportDialog.vue`