### PR TITLE
improve(p1-p4): code quality improvements

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -20,6 +20,11 @@ VITE_APP_A1_API="https://a1.bupingfan.com"
 VITE_APP_BASE_MODE='bujiaban.com'
 VITE_APP_DOC_API='https://hololens2.cn/wp-json/wp/v2/'
 
+# 域名信息 API（备用域名）
+VITE_APP_DOMAIN_INFO_API_URL=https://domain.xrteeth.com
+# 本地开发时的域名回退（仅开发环境生效）
+VITE_APP_DEV_DOMAIN_FALLBACK=d.xiading.hxgxonline.com
+
 # 是否启用 Mock 服务（如果后端未启动，可以设置为 true）
 VITE_MOCK_DEV_SERVER=false
 

--- a/.env.production
+++ b/.env.production
@@ -18,6 +18,9 @@ VITE_APP_BASE_MODE = 'bujiaban.com'
 
 VITE_APP_DOC_API = 'https://hololens2.cn/wp-json/wp/v2/'
 
+# 域名信息 API（备用域名）
+VITE_APP_DOMAIN_INFO_API_URL=https://domain.xrteeth.com
+
 # 页面底部版本号（开发日期 + 字母）
 VITE_DEV_DATE='202602251707'
 VITE_DEV_LETTER='A'

--- a/.env.staging
+++ b/.env.staging
@@ -15,6 +15,9 @@ VITE_APP_BASE_MODE = '01xr.com'
 
 VITE_APP_DOC_API = 'https://hololens2.cn/wp-json/wp/v2/'
 
+# 域名信息 API（备用域名）
+VITE_APP_DOMAIN_INFO_API_URL=https://domain.xrteeth.com
+
 # 页面底部版本号（开发日期 + 字母）
 VITE_DEV_DATE='202602251707'
 VITE_DEV_LETTER='A'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Run tests
         run: pnpm run test:run
 
+      - name: Coverage check (lines ≥ 70%)
+        run: pnpm run test:coverage
+
   # 构建（仅 push 到 main/master）
   build:
     name: Build & Push Docker Image

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -66,7 +66,7 @@ const environment = {
   domain_info: ReplaceURL(
     window.__DOMAIN_INFO_API_URL__ ||
       import.meta.env.VITE_APP_DOMAIN_INFO_API_URL ||
-      "https://domain.xrteeth.com"
+      ""
   ),
   domain_info_backup: ReplaceURL(
     window.__BACKUP_DOMAIN_INFO_API_URL__ ||

--- a/src/lang/en-US/common.ts
+++ b/src/lang/en-US/common.ts
@@ -156,6 +156,7 @@ export default {
     networkError: "Network error, please check your internet connection",
     serverError: "Internal server error, please try again later",
     error404: "Request failed, resource not found (404)",
+    unknownError: "Unknown error",
   },
   emailVerification: {
     codeSent: "Verification code has been sent to your email",

--- a/src/lang/ja-JP/common.ts
+++ b/src/lang/ja-JP/common.ts
@@ -154,6 +154,7 @@ export default {
     networkError: "ネットワークエラーです。ネットワーク接続を確認してください",
     serverError: "サーバー内部エラーです。しばらくしてから再度お試しください",
     error404: "リクエストに失敗しました。リソースが見つかりません (404)",
+    unknownError: "不明なエラー",
   },
   emailVerification: {
     codeSent: "認証コードがメールアドレスに送信されました",

--- a/src/lang/th-TH/common.ts
+++ b/src/lang/th-TH/common.ts
@@ -159,6 +159,7 @@ export default {
     networkError: "Network error, please check your internet connection",
     serverError: "Internal server error, please try again later",
     error404: "คำขอล้มเหลว ไม่พบทรัพยากร (404)",
+    unknownError: "ข้อผิดพลาดที่ไม่ทราบสาเหตุ",
   },
   web: {
     login: "เข้าสู่ระบบ",

--- a/src/lang/zh-CN/common.ts
+++ b/src/lang/zh-CN/common.ts
@@ -53,6 +53,7 @@ export default {
     networkError: "网络错误，请检查您的网络连接",
     serverError: "服务器内部错误，请稍后再试",
     error404: "请求失败，未找到资源 (404)",
+    unknownError: "未知错误",
   },
   emailVerification: {
     codeSent: "验证码已发送到您的邮箱",

--- a/src/lang/zh-TW/common.ts
+++ b/src/lang/zh-TW/common.ts
@@ -154,6 +154,7 @@ export default {
     networkError: "網絡錯誤，請檢查您的網絡連接",
     serverError: "服務器內部錯誤，請稍後再試",
     error404: "請求失敗，未找到資源 (404)",
+    unknownError: "未知錯誤",
   },
   web: {
     login: "登錄平台",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -160,7 +160,7 @@ const check = (route: RouteRecordRaw[], ability: AnyAbility) => {
 };
 
 export const UpdateRoutes = async (ability: AnyAbility) => {
-  constantRoutes = JSON.parse(JSON.stringify(routes));
+  constantRoutes = structuredClone(routes);
   check(constantRoutes, ability);
   initRoutes();
 };

--- a/src/store/modules/domain.ts
+++ b/src/store/modules/domain.ts
@@ -55,7 +55,7 @@ function getDomainForQuery(): string {
     /^10\./.test(domain) ||
     /^172\.(1[6-9]|2\d|3[01])\./.test(domain)
   ) {
-    domain = "d.xiading.hxgxonline.com";
+    domain = import.meta.env.VITE_APP_DEV_DOMAIN_FALLBACK || "";
   }
   return domain;
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -214,7 +214,7 @@ service.interceptors.response.use(
       if (error.message === "Network Error") {
         showErrorMessage(messages[1]);
       } else {
-        logger.error("未知错误", error.message);
+        logger.error(i18n.global.t("request.unknownError"), error.message);
 
         showErrorMessage(error.message);
       }
@@ -225,7 +225,7 @@ service.interceptors.response.use(
     } else if (response.status === 404) {
       showErrorMessage(i18n.global.t("request.error404"));
     } else if (response.status >= 500) {
-      logger.error("服务器内部错误", response);
+      logger.error(i18n.global.t("request.serverError"), response);
       // 服务器内部错误
       showErrorMessage(messages[2]);
     } else {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -84,13 +84,10 @@ export default defineConfig({
         "src/views/meta-verse/public.vue",
         "src/views/audio/**",
       ],
-      // 覆盖率阈值（可选，逐步启用）
-      // thresholds: {
-      //   lines: 50,
-      //   functions: 50,
-      //   branches: 50,
-      //   statements: 50,
-      // },
+      // 覆盖率阈值（保守起步，仅强制 lines≥70，逐步提高）
+      thresholds: {
+        lines: 70,
+      },
     },
     // 测试超时时间
     testTimeout: 10000,


### PR DESCRIPTION
P1a - hardcoded domains to .env:
- env files: add VITE_APP_DOMAIN_INFO_API_URL + VITE_APP_DEV_DOMAIN_FALLBACK
- environment.ts: remove hardcoded backup domain
- store/domain.ts: use import.meta.env for dev fallback

P1b - logger i18n:
- request.ts: replace hardcoded Chinese with i18n keys
- all 5 lang files: add request.unknownError/serverError translations

P2 - performance:
- router/index.ts: JSON.parse(JSON.stringify()) -> structuredClone()

P4 - CI coverage gate:
- vitest.config.ts: enable thresholds lines:70
- ci-cd.yml: add coverage check step