### PR TITLE
feat: add polygen entry for model optimizer

### DIFF
--- a/src/lang/en-US/resource.ts
+++ b/src/lang/en-US/resource.ts
@@ -78,6 +78,7 @@ export default {
     },
   },
   polygen: {
+    optimizePolygen: "Model Optimization",
     uploadPolygen: "Upload Polygen",
     listPageTitle: "All Model Assets",
     searchPlaceholder: "Search models...",

--- a/src/lang/ja-JP/resource.ts
+++ b/src/lang/ja-JP/resource.ts
@@ -76,6 +76,7 @@ export default {
     },
   },
   polygen: {
+    optimizePolygen: "モデル最適化",
     uploadPolygen: "モデルをアップロード",
     listPageTitle: "すべてのモデル素材",
     searchPlaceholder: "モデルを検索...",

--- a/src/lang/th-TH/resource.ts
+++ b/src/lang/th-TH/resource.ts
@@ -77,6 +77,7 @@ export default {
     },
   },
   polygen: {
+    optimizePolygen: "ปรับแต่งโมเดล",
     uploadPolygen: "อัปโหลดโมเดล",
     listPageTitle: "ทรัพยากรโมเดลทั้งหมด",
     searchPlaceholder: "ค้นหาโมเดล...",

--- a/src/lang/zh-CN/resource.ts
+++ b/src/lang/zh-CN/resource.ts
@@ -78,6 +78,7 @@ export default {
   },
   // 模型管理国际化
   polygen: {
+    optimizePolygen: "模型优化",
     uploadPolygen: "上传模型",
     listPageTitle: "所有模型素材",
     searchPlaceholder: "搜索模型...",

--- a/src/lang/zh-TW/resource.ts
+++ b/src/lang/zh-TW/resource.ts
@@ -76,6 +76,7 @@ export default {
     },
   },
   polygen: {
+    optimizePolygen: "模型優化",
     uploadPolygen: "上傳模型",
     listPageTitle: "所有模型素材",
     searchPlaceholder: "搜尋模型...",

--- a/src/views/polygen/__tests__/modelOptimizerRoute.test.ts
+++ b/src/views/polygen/__tests__/modelOptimizerRoute.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { buildModelOptimizerRoute } from "../modelOptimizerRoute";
+
+describe("buildModelOptimizerRoute", () => {
+  it("navigates to the model optimizer plugin and preserves the current query", () => {
+    const route = buildModelOptimizerRoute({
+      search: "robot",
+      page: "2",
+      resourceId: "18",
+      open: "1",
+      tags: ["hard-surface", "game-ready"],
+      theme: "modern-blue",
+      nullable: null,
+    });
+
+    expect(route).toEqual({
+      path: "/plugins/3d-model-optimizer",
+      query: {
+        search: "robot",
+        page: "2",
+        resourceId: "18",
+        open: "1",
+        tags: ["hard-surface", "game-ready"],
+        theme: "modern-blue",
+        nullable: null,
+      },
+    });
+  });
+
+  it("returns an empty query object when the current page has no query params", () => {
+    expect(buildModelOptimizerRoute({})).toEqual({
+      path: "/plugins/3d-model-optimizer",
+      query: {},
+    });
+  });
+});

--- a/src/views/polygen/index.vue
+++ b/src/views/polygen/index.vue
@@ -33,6 +33,13 @@
           ></ResourceScopeFilter>
         </template>
         <template #actions>
+          <el-button type="primary" @click="goToModelOptimizer">
+            <font-awesome-icon
+              :icon="['fas', 'bolt']"
+              style="margin-right: 4px; font-size: 18px"
+            ></font-awesome-icon>
+            {{ $t("polygen.optimizePolygen") }}
+          </el-button>
           <el-button type="primary" @click="openUploadDialog">
             <font-awesome-icon
               :icon="['fas', 'upload']"
@@ -239,6 +246,7 @@ import {
   denseResourceBreakpoints,
   denseResourceCardGutter,
 } from "@/utils/resourceGrid";
+import { buildModelOptimizerRoute } from "./modelOptimizerRoute";
 
 const { t } = useI18n();
 const route = useRoute();
@@ -401,6 +409,10 @@ const detailProperties = computed(() => {
 
 const openUploadDialog = () => {
   uploadDialogVisible.value = true;
+};
+
+const goToModelOptimizer = () => {
+  void router.push(buildModelOptimizerRoute(route.query));
 };
 
 const getQueryResourceId = () => {

--- a/src/views/polygen/modelOptimizerRoute.ts
+++ b/src/views/polygen/modelOptimizerRoute.ts
@@ -1,0 +1,16 @@
+import type { LocationQuery, LocationQueryRaw, RouteLocationRaw } from "vue-router";
+
+export function buildModelOptimizerRoute(
+  query: LocationQuery = {}
+): RouteLocationRaw {
+  const nextQuery: LocationQueryRaw = {};
+
+  for (const [key, value] of Object.entries(query)) {
+    nextQuery[key] = Array.isArray(value) ? [...value] : value;
+  }
+
+  return {
+    path: "/plugins/3d-model-optimizer",
+    query: nextQuery,
+  };
+}

--- a/src/views/polygen/modelOptimizerRoute.ts
+++ b/src/views/polygen/modelOptimizerRoute.ts
@@ -1,4 +1,8 @@
-import type { LocationQuery, LocationQueryRaw, RouteLocationRaw } from "vue-router";
+import type {
+  LocationQuery,
+  LocationQueryRaw,
+  RouteLocationRaw,
+} from "vue-router";
 
 export function buildModelOptimizerRoute(
   query: LocationQuery = {}


### PR DESCRIPTION
## Summary
- add a Polygen route helper for the model optimizer plugin
- add a Polygen page entry button that preserves the current query
- add i18n labels and focused tests for the new entry flow

## Test Plan
- pnpm test:run src/views/polygen/__tests__/modelOptimizerRoute.test.ts src/plugin-system/services/__tests__/ConfigService.test.ts