### PR TITLE
修复 web 脚本校验、场景发布和资源状态同步问题

### DIFF
--- a/src/components/StandardPage/StandardUploadDialog.vue
+++ b/src/components/StandardPage/StandardUploadDialog.vue
@@ -63,6 +63,16 @@
         <div class="footer-col">最大 {{ maxSize }}MB</div>
       </div>
     </div>
+
+    <div v-if="compatibilityNotes.length" class="compatibility-notes">
+      <div class="compatibility-title">
+        <font-awesome-icon :icon="['fas', 'circle-info']"></font-awesome-icon>
+        {{ compatibilityTitle }}
+      </div>
+      <ul>
+        <li v-for="note in compatibilityNotes" :key="note">{{ note }}</li>
+      </ul>
+    </div>
   </el-dialog>
 </template>
 
@@ -70,6 +80,7 @@
 import { logger } from "@/utils/logger";
 import { ref, computed } from "vue";
 import { useI18n } from "vue-i18n";
+import { ElMessageBox } from "element-plus";
 import { Message } from "@/components/Dialog";
 import { useFileStore } from "@/store/modules/config";
 import { UploadFileType } from "@/api/user/model";
@@ -90,6 +101,8 @@ const props = withDefaults(
     maxSize?: number; // MB
     multiple?: boolean;
     showEffectTypeSelect?: boolean;
+    compatibilityTitle?: string;
+    compatibilityNotes?: string[];
   }>(),
   {
     title: "上传资源",
@@ -99,6 +112,8 @@ const props = withDefaults(
     maxSize: 0,
     multiple: true,
     showEffectTypeSelect: false,
+    compatibilityTitle: "兼容说明",
+    compatibilityNotes: () => [],
   }
 );
 
@@ -115,6 +130,9 @@ const selectedFiles = ref<File[]>([]);
 const uploadedCount = ref(0);
 const totalFilesCount = ref(0);
 const uploadedIds = ref<number[]>([]);
+const rejectedModelFiles = ref<{ name: string; reasons: string[] }[]>([]);
+const uploadedModelFiles = ref<string[]>([]);
+const modelSummaryShown = ref(false);
 
 // Progress tracking
 const currentStage = ref(0); // 0: Idle, 1: Hashing, 2: Uploading, 3: Saving
@@ -158,6 +176,266 @@ const supportedFormats = computed(() => {
     .join(", ");
 });
 
+type GlbJsonChunk = {
+  extensionsRequired?: string[];
+  extensionsUsed?: string[];
+  images?: Array<{
+    mimeType?: string;
+    uri?: string;
+  }>;
+  meshes?: Array<{
+    primitives?: Array<{
+      extensions?: Record<string, unknown>;
+    }>;
+  }>;
+};
+
+const SUPPORTED_MODEL_TEXTURE_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/ktx",
+  "image/ktx2",
+]);
+
+const getUriTextureMimeType = (uri: string): string | null => {
+  const normalizedUri = uri.toLowerCase();
+  if (normalizedUri.startsWith("data:")) {
+    const match = normalizedUri.match(/^data:([^;,]+)/);
+    return match?.[1] ?? null;
+  }
+  const pathWithoutQuery = normalizedUri.split(/[?#]/)[0];
+  if (pathWithoutQuery.endsWith(".png")) return "image/png";
+  if (
+    pathWithoutQuery.endsWith(".jpg") ||
+    pathWithoutQuery.endsWith(".jpeg")
+  ) {
+    return "image/jpeg";
+  }
+  if (pathWithoutQuery.endsWith(".ktx")) return "image/ktx";
+  if (pathWithoutQuery.endsWith(".ktx2")) return "image/ktx2";
+  if (pathWithoutQuery.endsWith(".webp")) return "image/webp";
+  return null;
+};
+
+const parseGlbJson = async (file: File): Promise<GlbJsonChunk> => {
+  const buffer = await file.arrayBuffer();
+  const view = new DataView(buffer);
+  const decoder = new TextDecoder();
+
+  if (buffer.byteLength < 20 || decoder.decode(buffer.slice(0, 4)) !== "glTF") {
+    throw new Error(t("upload.invalidGlb"));
+  }
+
+  const version = view.getUint32(4, true);
+  if (version !== 2) {
+    throw new Error(t("upload.unsupportedGlbVersion", { version }));
+  }
+
+  let offset = 12;
+  while (offset + 8 <= buffer.byteLength) {
+    const chunkLength = view.getUint32(offset, true);
+    const chunkType = decoder.decode(buffer.slice(offset + 4, offset + 8));
+    offset += 8;
+
+    if (offset + chunkLength > buffer.byteLength) break;
+
+    if (chunkType === "JSON") {
+      const jsonText = decoder.decode(buffer.slice(offset, offset + chunkLength));
+      return JSON.parse(jsonText.trim()) as GlbJsonChunk;
+    }
+
+    offset += chunkLength;
+  }
+
+  throw new Error(t("upload.missingGlbJson"));
+};
+
+const getUnsupportedModelReasons = async (file: File): Promise<string[]> => {
+  if (props.dir !== "polygen" || !file.name.toLowerCase().endsWith(".glb")) {
+    return [];
+  }
+
+  let gltf: GlbJsonChunk;
+  try {
+    gltf = await parseGlbJson(file);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : t("upload.invalidGlb");
+    return [message];
+  }
+
+  const reasons: string[] = [];
+  const extensionNames = new Set([
+    ...(gltf.extensionsRequired ?? []),
+    ...(gltf.extensionsUsed ?? []),
+  ]);
+  const hasDracoExtension =
+    extensionNames.has("KHR_draco_mesh_compression") ||
+    Boolean(
+      gltf.meshes?.some((mesh) =>
+        mesh.primitives?.some(
+          (primitive) => primitive.extensions?.KHR_draco_mesh_compression
+        )
+      )
+    );
+
+  if (hasDracoExtension) {
+    reasons.push(t("upload.unsupportedDraco"));
+  }
+
+  const unsupportedTextureTypes = new Set<string>();
+  for (const image of gltf.images ?? []) {
+    const mimeType = (
+      image.mimeType ||
+      (image.uri ? getUriTextureMimeType(image.uri) : "") ||
+      ""
+    ).toLowerCase();
+
+    if (!mimeType) continue;
+    if (mimeType === "image/webp") {
+      unsupportedTextureTypes.add("WebP");
+      continue;
+    }
+    if (!SUPPORTED_MODEL_TEXTURE_MIME_TYPES.has(mimeType)) {
+      unsupportedTextureTypes.add(mimeType.replace(/^image\//, "").toUpperCase());
+    }
+  }
+
+  if (unsupportedTextureTypes.size > 0) {
+    reasons.push(
+      t("upload.unsupportedTextureFormats", {
+        formats: Array.from(unsupportedTextureTypes).join(", "),
+      })
+    );
+  }
+
+  return reasons;
+};
+
+const filterUnsupportedModelFiles = async (files: File[]): Promise<File[]> => {
+  const checkedFiles: File[] = [];
+
+  for (const file of files) {
+    const reasons = await getUnsupportedModelReasons(file);
+    if (reasons.length > 0) {
+      rejectedModelFiles.value.push({ name: file.name, reasons });
+      continue;
+    }
+    checkedFiles.push(file);
+  }
+
+  return checkedFiles;
+};
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const renderModelUploadList = (
+  items: string[],
+  emptyText: string
+): string => {
+  if (items.length === 0) {
+    return `<div class="model-upload-summary-empty">${escapeHtml(emptyText)}</div>`;
+  }
+
+  return `<ul>${items
+    .map((name) => `<li>${escapeHtml(name)}</li>`)
+    .join("")}</ul>`;
+};
+
+const renderRejectedModelUploadList = (
+  items: { name: string; reasons: string[] }[],
+  emptyText: string
+): string => {
+  if (items.length === 0) {
+    return `<div class="model-upload-summary-empty">${escapeHtml(emptyText)}</div>`;
+  }
+
+  return `<ul>${items
+    .map(
+      (item) =>
+        `<li><strong>${escapeHtml(item.name)}</strong><div>${escapeHtml(
+          item.reasons.join("；")
+        )}</div></li>`
+    )
+    .join("")}</ul>`;
+};
+
+const showModelUploadSummary = async (): Promise<void> => {
+  if (
+    props.dir !== "polygen" ||
+    modelSummaryShown.value ||
+    rejectedModelFiles.value.length === 0
+  ) {
+    return;
+  }
+
+  modelSummaryShown.value = true;
+
+  const html = `
+    <div class="model-upload-summary">
+      <section>
+        <h4>${escapeHtml(t("upload.uploadedModels"))}</h4>
+        ${renderModelUploadList(
+          uploadedModelFiles.value,
+          t("upload.noUploadedModels")
+        )}
+      </section>
+      <section>
+        <h4>${escapeHtml(t("upload.rejectedModels"))}</h4>
+        ${renderRejectedModelUploadList(
+          rejectedModelFiles.value,
+          t("upload.noRejectedModels")
+        )}
+      </section>
+    </div>
+    <style>
+      .model-upload-summary { display: grid; gap: 14px; text-align: left; }
+      .model-upload-summary h4 { margin: 0 0 8px; font-size: 14px; color: #1e293b; }
+      .model-upload-summary ul { margin: 0; padding-left: 18px; }
+      .model-upload-summary li { margin: 6px 0; line-height: 1.45; }
+      .model-upload-summary li div { margin-top: 2px; color: #ef4444; font-size: 13px; }
+      .model-upload-summary-empty { color: #94a3b8; font-size: 13px; }
+    </style>
+  `;
+
+  try {
+    await ElMessageBox.alert(html, t("upload.modelUploadSummaryTitle"), {
+      confirmButtonText: t("common.confirm"),
+      dangerouslyUseHTMLString: true,
+      customClass: "model-upload-summary-dialog",
+    });
+  } catch {
+    // Alert may reject if closed; no follow-up needed.
+  }
+};
+
+const finishUploadFile = (file: File, id: number): void => {
+  uploadedCount.value++;
+  uploadedIds.value.push(id);
+
+  if (props.dir === "polygen") {
+    if (id > 0) {
+      uploadedModelFiles.value.push(file.name);
+    } else {
+      rejectedModelFiles.value.push({
+        name: file.name,
+        reasons: [t("upload.saveResourceFailed")],
+      });
+    }
+  }
+
+  if (uploadedCount.value === totalFilesCount.value) {
+    void showModelUploadSummary();
+    emit("success", uploadedIds.value);
+  }
+};
+
 // Drag & Drop Handlers
 const onDragOver = (_e: DragEvent) => {
   isDragOver.value = true;
@@ -196,20 +474,40 @@ const triggerFileSelect = async () => {
 };
 
 const processFiles = async (files: File[]) => {
+  if (props.dir === "polygen") {
+    rejectedModelFiles.value = [];
+    uploadedModelFiles.value = [];
+    modelSummaryShown.value = false;
+  }
+
   // 1. Validate Size
   if (props.maxSize > 0) {
     const maxBytes = props.maxSize * 1024 * 1024;
     const oversized = files.filter((f) => f.size > maxBytes);
     if (oversized.length > 0) {
       const names = oversized.map((f) => f.name).join(", ");
-      Message.error(
-        `${t("upload.fileTooLarge", { size: props.maxSize })}: ${names}`
-      );
+      if (props.dir === "polygen") {
+        oversized.forEach((file) => {
+          rejectedModelFiles.value.push({
+            name: file.name,
+            reasons: [t("upload.fileTooLarge", { size: props.maxSize })],
+          });
+        });
+      } else {
+        Message.error(
+          `${t("upload.fileTooLarge", { size: props.maxSize })}: ${names}`
+        );
+      }
       files = files.filter((f) => f.size <= maxBytes);
     }
   }
 
-  if (files.length === 0) return;
+  files = await filterUnsupportedModelFiles(files);
+
+  if (files.length === 0) {
+    await showModelUploadSummary();
+    return;
+  }
 
   selectedFiles.value = files;
   isDisabled.value = true;
@@ -350,7 +648,11 @@ const uploadSingleFile = async (file: File) => {
     stageProgress.value[2] = 100;
   } catch (err) {
     logger.error(`Error uploading ${file.name}`, err);
-    Message.error(`Upload failed: ${file.name}`);
+    if (props.dir === "polygen") {
+      finishUploadFile(file, -1);
+    } else {
+      Message.error(`Upload failed: ${file.name}`);
+    }
   } finally {
     if (uploadedCount.value === totalFilesCount.value) {
       setTimeout(() => {
@@ -387,11 +689,7 @@ const saveFileRecord = async (
       response.data.id,
       totalFilesCount.value,
       (id: number) => {
-        uploadedCount.value++;
-        uploadedIds.value.push(id);
-        if (uploadedCount.value === totalFilesCount.value) {
-          emit("success", uploadedIds.value);
-        }
+        finishUploadFile(file, id);
       },
       undefined, // effectType
       info,
@@ -608,6 +906,40 @@ const handleDialogClose = () => {
 .footer-col {
   flex: 1;
   text-align: center;
+}
+
+.compatibility-notes {
+  padding: 14px 16px;
+  margin-top: 14px;
+  color: var(--text-secondary, #64748b);
+  background: var(--bg-secondary, #f8fafc);
+  border: var(--border-width, 1px) solid var(--border-color, #e2e8f0);
+  border-radius: 12px;
+}
+
+.compatibility-title {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary, #1e293b);
+
+  .svg-inline--fa {
+    color: var(--primary-color, #0ea5e9);
+  }
+}
+
+.compatibility-notes ul {
+  padding-left: 18px;
+  margin: 0;
+}
+
+.compatibility-notes li {
+  margin: 4px 0;
+  font-size: 13px;
+  line-height: 1.55;
 }
 
 // Override Dialog styles

--- a/src/composables/useResourceScopeFilter.ts
+++ b/src/composables/useResourceScopeFilter.ts
@@ -308,6 +308,53 @@ export function useResourceScopeFilter(resourceType: string, pageSize = 24) {
     return true;
   };
 
+  const filterDeletedResources = (
+    resources: ResourceInfo[] | undefined,
+    deletedIds: Set<number>
+  ): ResourceInfo[] => {
+    if (!Array.isArray(resources)) return [];
+    return resources.filter((resource) => !deletedIds.has(resource.id));
+  };
+
+  const removeResourcesByIds = (ids: Array<number | string>) => {
+    const deletedIds = new Set(
+      ids
+        .map((id) => Number(id))
+        .filter((id) => Number.isFinite(id))
+    );
+
+    if (deletedIds.size === 0) return;
+
+    scopedSceneResources.value = filterDeletedResources(
+      scopedSceneResources.value,
+      deletedIds
+    );
+    scopedEntityResources.value = filterDeletedResources(
+      scopedEntityResources.value,
+      deletedIds
+    );
+
+    entities.value = entities.value.map((entity) => ({
+      ...entity,
+      resources: filterDeletedResources(entity.resources, deletedIds),
+    }));
+
+    sceneCache.forEach((detail) => {
+      detail.resources = filterDeletedResources(detail.resources, deletedIds);
+      detail.metas = detail.metas?.map((meta) => ({
+        ...meta,
+        resources: filterDeletedResources(meta.resources, deletedIds),
+      }));
+    });
+
+    entityResourcesCache.forEach((resources, entityId) => {
+      entityResourcesCache.set(
+        entityId,
+        filterDeletedResources(resources, deletedIds)
+      );
+    });
+  };
+
   watch(
     showSceneSelect,
     async (visible) => {
@@ -338,6 +385,7 @@ export function useResourceScopeFilter(resourceType: string, pageSize = 24) {
     handleScopedSearch,
     handleScopedSort,
     handleScopedPageChange,
+    removeResourcesByIds,
     loadScenes,
   };
 }

--- a/src/composables/useScriptEditorBase.ts
+++ b/src/composables/useScriptEditorBase.ts
@@ -722,6 +722,22 @@ export function useScriptEditorBase(options: UseScriptEditorBaseOptions) {
         ready = true;
         options.onReady();
       } else if (msg.type === "RESPONSE") {
+        if (payload.action === "save-error") {
+          const message =
+            typeof payload.message === "string"
+              ? payload.message
+              : t(options.i18nKeys.error1);
+          Message.error(message);
+          isSaving.value = false;
+          if (saveReject) {
+            saveReject(new Error(message));
+            saveReject = null;
+          }
+          saveResolve = null;
+          pendingSavePromise = null;
+          return;
+        }
+
         if (payload.action === "save" && !payload.noChange) {
           // --- 有变更的保存响应 ---
           if (!isEditorPostPayload(payload)) {

--- a/src/lang/en-US/resource.ts
+++ b/src/lang/en-US/resource.ts
@@ -109,6 +109,15 @@ export default {
       info: "Deletion canceled",
     },
     uploadFile: "Select a polygen (.glb file) and upload it",
+    uploadCompatibility: {
+      title: "GLB compatibility notes",
+      textureFormats:
+        "Use PNG, JPEG/JPG, or KTX/KTX2 textures. WebP textures are not supported by the client.",
+      noDraco:
+        "KHR_draco_mesh_compression / Draco mesh compression is not supported.",
+      recommendation:
+        "Before uploading, disable Draco compression and convert WebP textures to PNG, JPEG/JPG, or KTX/KTX2.",
+    },
     view: {
       title: "Ploygen Name: ",
       info: {
@@ -427,6 +436,19 @@ export default {
     fileTooLarge: "File exceeds {size}MB limit",
     fileSizeExceededList:
       "The following files exceed the {size}MB limit: {names}",
+    modelCompatibilityRejected: "{name} cannot be uploaded: {reasons}",
+    unsupportedDraco: "contains unsupported Draco mesh compression",
+    unsupportedTextureFormats:
+      "contains unsupported texture format(s): {formats}",
+    invalidGlb: "not a valid GLB file",
+    missingGlbJson: "GLB file is missing JSON data",
+    unsupportedGlbVersion: "GLB v{version} is not supported; use glTF 2.0",
+    modelUploadSummaryTitle: "Model upload results",
+    uploadedModels: "Uploaded models",
+    rejectedModels: "Models that could not be uploaded",
+    noUploadedModels: "No models were uploaded",
+    noRejectedModels: "No rejected models",
+    saveResourceFailed: "Failed to save resource",
   },
   resource: {
     type: {

--- a/src/lang/ja-JP/resource.ts
+++ b/src/lang/ja-JP/resource.ts
@@ -106,6 +106,15 @@ export default {
       info: "削除がキャンセルされました",
     },
     uploadFile: "モデル(.glbファイル)を選択してアップロード",
+    uploadCompatibility: {
+      title: "GLB 互換性メモ",
+      textureFormats:
+        "テクスチャは PNG、JPEG/JPG、KTX/KTX2 形式を使用してください。クライアントでは WebP テクスチャは未対応です。",
+      noDraco:
+        "KHR_draco_mesh_compression / Draco メッシュ圧縮には対応していません。",
+      recommendation:
+        "アップロード前に Draco 圧縮を無効にし、WebP などのテクスチャを PNG、JPEG/JPG、または KTX/KTX2 に変換してください。",
+    },
     view: {
       title: "モデル名：",
       info: {
@@ -413,6 +422,21 @@ export default {
     fileTooLarge: "File exceeds {size}MB limit",
     fileSizeExceededList:
       "The following files exceed the {size}MB limit: {names}",
+    modelCompatibilityRejected:
+      "{name} はアップロードできません: {reasons}",
+    unsupportedDraco: "未対応の Draco メッシュ圧縮が含まれています",
+    unsupportedTextureFormats:
+      "未対応のテクスチャ形式が含まれています: {formats}",
+    invalidGlb: "有効な GLB ファイルではありません",
+    missingGlbJson: "GLB ファイルに JSON データがありません",
+    unsupportedGlbVersion:
+      "GLB v{version} は対応していません。glTF 2.0 を使用してください",
+    modelUploadSummaryTitle: "モデルアップロード結果",
+    uploadedModels: "正常にアップロードされたモデル",
+    rejectedModels: "アップロードできなかったモデル",
+    noUploadedModels: "正常にアップロードされたモデルはありません",
+    noRejectedModels: "アップロードできなかったモデルはありません",
+    saveResourceFailed: "リソースの保存に失敗しました",
   },
   resource: {
     type: {

--- a/src/lang/th-TH/resource.ts
+++ b/src/lang/th-TH/resource.ts
@@ -107,6 +107,15 @@ export default {
       info: "ยกเลิกการลบแล้ว",
     },
     uploadFile: "เลือกโมเดล (.glb) และอัปโหลด",
+    uploadCompatibility: {
+      title: "หมายเหตุความเข้ากันได้ของ GLB",
+      textureFormats:
+        "แนะนำให้ใช้เท็กซ์เจอร์ PNG, JPEG/JPG หรือ KTX/KTX2 ส่วนไคลเอนต์ยังไม่รองรับเท็กซ์เจอร์ WebP",
+      noDraco:
+        "ยังไม่รองรับ KHR_draco_mesh_compression / การบีบอัดเมชแบบ Draco",
+      recommendation:
+        "ก่อนอัปโหลด โปรดปิดการบีบอัด Draco และแปลงเท็กซ์เจอร์ WebP เป็น PNG, JPEG/JPG หรือ KTX/KTX2",
+    },
     view: {
       title: "ชื่อโมเดล: ",
       info: {
@@ -416,6 +425,20 @@ export default {
     fileTooLarge: "File exceeds {size}MB limit",
     fileSizeExceededList:
       "The following files exceed the {size}MB limit: {names}",
+    modelCompatibilityRejected: "ไม่สามารถอัปโหลด {name}: {reasons}",
+    unsupportedDraco: "มีการบีบอัดเมช Draco ที่ยังไม่รองรับ",
+    unsupportedTextureFormats:
+      "มีรูปแบบเท็กซ์เจอร์ที่ยังไม่รองรับ: {formats}",
+    invalidGlb: "ไม่ใช่ไฟล์ GLB ที่ถูกต้อง",
+    missingGlbJson: "ไฟล์ GLB ไม่มีข้อมูล JSON",
+    unsupportedGlbVersion:
+      "ยังไม่รองรับ GLB v{version}; โปรดใช้ glTF 2.0",
+    modelUploadSummaryTitle: "ผลการอัปโหลดโมเดล",
+    uploadedModels: "โมเดลที่อัปโหลดสำเร็จ",
+    rejectedModels: "โมเดลที่ไม่สามารถอัปโหลดได้",
+    noUploadedModels: "ไม่มีโมเดลที่อัปโหลดสำเร็จ",
+    noRejectedModels: "ไม่มีโมเดลที่ถูกปฏิเสธ",
+    saveResourceFailed: "บันทึกทรัพยากรล้มเหลว",
   },
   resource: {
     type: {

--- a/src/lang/zh-CN/resource.ts
+++ b/src/lang/zh-CN/resource.ts
@@ -108,6 +108,12 @@ export default {
       info: "已取消删除",
     },
     uploadFile: "选择模型（.glb文件），并上传",
+    uploadCompatibility: {
+      title: "GLB 兼容说明",
+      textureFormats: "贴图建议使用 PNG、JPEG/JPG、KTX/KTX2 格式；客户端暂不支持 WebP 贴图。",
+      noDraco: "暂不支持 KHR_draco_mesh_compression / Draco 网格压缩。",
+      recommendation: "上传前请关闭 Draco 压缩，并将 WebP 等贴图转换为 PNG、JPEG/JPG 或 KTX/KTX2。",
+    },
     view: {
       title: "模型名称：",
       info: {
@@ -421,6 +427,18 @@ export default {
     maxSizeLimit: "单个文件最大 {size}MB",
     fileTooLarge: "文件超过 {size}MB 限制",
     fileSizeExceededList: "以下文件超过 {size}MB 限制: {names}",
+    modelCompatibilityRejected: "{name} 无法上传：{reasons}",
+    unsupportedDraco: "包含不支持的 Draco 网格压缩",
+    unsupportedTextureFormats: "包含不支持的贴图格式：{formats}",
+    invalidGlb: "不是有效的 GLB 文件",
+    missingGlbJson: "GLB 文件缺少 JSON 数据",
+    unsupportedGlbVersion: "不支持 GLB v{version}，请使用 glTF 2.0",
+    modelUploadSummaryTitle: "模型上传结果",
+    uploadedModels: "正常上传的模型",
+    rejectedModels: "无法上传的模型",
+    noUploadedModels: "暂无正常上传的模型",
+    noRejectedModels: "暂无无法上传的模型",
+    saveResourceFailed: "资源保存失败",
   },
   resource: {
     type: {

--- a/src/lang/zh-TW/resource.ts
+++ b/src/lang/zh-TW/resource.ts
@@ -106,6 +106,12 @@ export default {
       info: "已取消刪除",
     },
     uploadFile: "選擇模型（.glb文件），並上傳",
+    uploadCompatibility: {
+      title: "GLB 相容說明",
+      textureFormats: "貼圖建議使用 PNG、JPEG/JPG、KTX/KTX2 格式；客戶端暫不支援 WebP 貼圖。",
+      noDraco: "暫不支援 KHR_draco_mesh_compression / Draco 網格壓縮。",
+      recommendation: "上傳前請關閉 Draco 壓縮，並將 WebP 等貼圖轉換為 PNG、JPEG/JPG 或 KTX/KTX2。",
+    },
     view: {
       title: "模型名稱：",
       info: {
@@ -410,6 +416,18 @@ export default {
     maxSizeLimit: "單個文件最大 {size}MB",
     fileTooLarge: "文件超過 {size}MB 限制",
     fileSizeExceededList: "以下文件超過 {size}MB 限制: {names}",
+    modelCompatibilityRejected: "{name} 無法上傳：{reasons}",
+    unsupportedDraco: "包含不支援的 Draco 網格壓縮",
+    unsupportedTextureFormats: "包含不支援的貼圖格式：{formats}",
+    invalidGlb: "不是有效的 GLB 文件",
+    missingGlbJson: "GLB 文件缺少 JSON 數據",
+    unsupportedGlbVersion: "不支援 GLB v{version}，請使用 glTF 2.0",
+    modelUploadSummaryTitle: "模型上傳結果",
+    uploadedModels: "正常上傳的模型",
+    rejectedModels: "無法上傳的模型",
+    noUploadedModels: "暫無正常上傳的模型",
+    noRejectedModels: "暫無無法上傳的模型",
+    saveResourceFailed: "資源保存失敗",
   },
   resource: {
     type: {

--- a/src/views/meta-verse/index.vue
+++ b/src/views/meta-verse/index.vue
@@ -186,6 +186,17 @@
             ></font-awesome-icon>
             {{ t("route.project.sceneEditor") }}
           </button>
+          <button
+            class="btn-pill-primary enter-edit-btn publish-scene-btn"
+            :disabled="isPublishingSnapshot"
+            @click="handlePublishSnapshot"
+          >
+            <font-awesome-icon
+              :icon="['fas', isPublishingSnapshot ? 'spinner' : 'cloud-arrow-up']"
+              :spin="isPublishingSnapshot"
+            ></font-awesome-icon>
+            {{ t("verse.view.sceneEditor.publishScene") }}
+          </button>
           <div class="actions-row">
             <button class="btn-pill-secondary" @click="handleExport">
               <font-awesome-icon
@@ -426,6 +437,7 @@ import {
   removePublic,
   addTag,
   removeTag,
+  takePhoto,
 } from "@/api/v1/verse";
 import { exportScene } from "@/services/scene-package/export-service";
 import { getPicture } from "@/api/v1/resources/index";
@@ -446,6 +458,7 @@ import {
 const { t } = useI18n();
 const router = useRouter();
 const createdDialog = ref<InstanceType<typeof Create> | null>(null);
+const isPublishingSnapshot = ref(false);
 
 const {
   items,
@@ -912,6 +925,27 @@ const handleExport = async () => {
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : t("ui.unknownError");
     Message.error(t("ui.exportFailed", { message }));
+  }
+};
+
+const handlePublishSnapshot = async () => {
+  if (!currentVerse.value || isPublishingSnapshot.value) return;
+
+  isPublishingSnapshot.value = true;
+  try {
+    await takePhoto(currentVerse.value.id);
+    const response = await getVerse(
+      currentVerse.value.id,
+      "image,author,verseTags,metas"
+    );
+    currentVerse.value = response.data;
+    await refresh();
+    Message.success(t("verse.view.sceneEditor.publishSuccess"));
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    Message.error(message || t("verse.view.sceneEditor.error1"));
+  } finally {
+    isPublishingSnapshot.value = false;
   }
 };
 
@@ -1520,6 +1554,16 @@ const formatItemDate = (dateStr?: string) => {
     --standard-page-max-radius,
     calc(var(--radius-lg, 24px) / 3)
   ) !important;
+}
+
+.publish-scene-btn {
+  margin-top: 10px;
+}
+
+.publish-scene-btn:disabled {
+  cursor: not-allowed !important;
+  opacity: 0.65;
+  transform: none !important;
 }
 
 :deep(.panel-actions .dual-primary-btn) {

--- a/src/views/meta-verse/index.vue
+++ b/src/views/meta-verse/index.vue
@@ -292,7 +292,7 @@
               <div class="visibility-group">
                 <button
                   class="vis-btn"
-                  :class="{ active: !currentVerse?.public }"
+                  :class="{ active: !currentVerseIsPublic }"
                   @click="handleVisibilityChange(false)"
                 >
                   <font-awesome-icon
@@ -302,7 +302,7 @@
                 </button>
                 <button
                   class="vis-btn"
-                  :class="{ active: currentVerse?.public }"
+                  :class="{ active: currentVerseIsPublic }"
                   @click="handleVisibilityChange(true)"
                 >
                   <font-awesome-icon
@@ -489,6 +489,28 @@ const detailVisible = ref(false);
 const detailLoading = ref(false);
 const currentVerse = ref<VerseData | null>(null);
 const ability = useAbility();
+
+const isPublicValue = (value: unknown) => {
+  return value === true || value === 1 || value === "1" || value === "true";
+};
+
+const currentVerseIsPublic = computed(() =>
+  isPublicValue(currentVerse.value?.public)
+);
+
+const syncVerseVisibility = (verseId: number, isPublic: boolean) => {
+  if (currentVerse.value?.id === verseId) {
+    currentVerse.value = {
+      ...currentVerse.value,
+      public: isPublic,
+    };
+  }
+
+  const item = (items.value ?? []).find((verse) => verse.id === verseId);
+  if (item) {
+    item.public = isPublic;
+  }
+};
 
 const canManage = computed(() => {
   return (
@@ -819,15 +841,16 @@ const handleRemoveTag = async (tagId: number) => {
 };
 
 const handleVisibilityChange = async (isPublic: boolean) => {
-  if (!currentVerse.value || currentVerse.value.public === isPublic) return;
+  if (!currentVerse.value || currentVerseIsPublic.value === isPublic) return;
 
   try {
+    const verseId = currentVerse.value.id;
     if (isPublic) {
-      await addPublic(currentVerse.value.id);
+      await addPublic(verseId);
     } else {
-      await removePublic(currentVerse.value.id);
+      await removePublic(verseId);
     }
-    currentVerse.value.public = isPublic;
+    syncVerseVisibility(verseId, isPublic);
     Message.success(
       isPublic
         ? t("verse.view.public.addSuccess")

--- a/src/views/polygen/index.vue
+++ b/src/views/polygen/index.vue
@@ -715,6 +715,7 @@ const handleDelete = async () => {
       }
     );
     await deletePolygen(String(currentPolygen.value.id));
+    scopeFilter.removeResourcesByIds([currentPolygen.value.id]);
     viewDialogVisible.value = false;
     clearDetailQuery();
     refresh();
@@ -792,6 +793,7 @@ const deletedWindow = async (
       }
     );
     await deletePolygen(String(item.id));
+    scopeFilter.removeResourcesByIds([item.id]);
     refresh();
     Message.success(t("polygen.confirm.success"));
   } catch {
@@ -830,6 +832,7 @@ const handleBatchDelete = async () => {
       await deletePolygen(String(item.id));
     }
 
+    scopeFilter.removeResourcesByIds(selected.map((item) => item.id));
     clearSelection();
     refresh();
     Message.success(

--- a/src/views/polygen/index.vue
+++ b/src/views/polygen/index.vue
@@ -140,6 +140,8 @@
         :file-type="fileType"
         :max-size="30"
         :title="$t('polygen.uploadPolygen')"
+        :compatibility-title="t('polygen.uploadCompatibility.title')"
+        :compatibility-notes="modelCompatibilityNotes"
         @save-resource="savePolygen"
         @success="handleUploadSuccess"
       >
@@ -347,6 +349,11 @@ const handleCancelSelectAllPage = () => {
 // Dialog state
 const uploadDialogVisible = ref(false);
 const fileType = ref(".glb");
+const modelCompatibilityNotes = computed(() => [
+  t("polygen.uploadCompatibility.textureFormats"),
+  t("polygen.uploadCompatibility.noDraco"),
+  t("polygen.uploadCompatibility.recommendation"),
+]);
 const viewDialogVisible = ref(false);
 
 // Detail panel state


### PR DESCRIPTION
## 修改内容
- 修复脚本编辑器保存校验失败时的提示和保存状态恢复。
- 在场景详情弹窗新增「发布场景」入口，可在外部直接更新场景快照。
- 补充模型上传兼容说明，并在上传前检测 WebP 贴图、Draco 网格压缩等客户端不支持内容。
- 多模型上传时区分正常上传与无法上传列表，并展示无法上传原因。
- 修复按场景或实体筛选资源后删除模型仍显示，需要刷新才消失的问题。
- 修复场景公开或设为私有后详情弹窗仍显示旧状态的问题。

## 验证
- pnpm run type-check
- pnpm run build
